### PR TITLE
start-server.sh not working on zsh

### DIFF
--- a/files/adminer/install.sh
+++ b/files/adminer/install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Adminer installer (Not installed by default)
 # You should run this script manually
 

--- a/files/start-server.sh
+++ b/files/start-server.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 cd $(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
The `start-server.sh` and `adminer/install.sh` scripts expect bash shell, but does not include a shebang line. This causes the scripts to fail when called from zsh shell.